### PR TITLE
Feat - refreshToken 기반 토큰 업데이트 기능 구현, 로그아웃 기능 구현 #9

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@prisma/client": "^5.14.0",
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.6",
+    "crypto": "^1.0.1",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "joi": "^17.13.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,7 @@ enum Status {
   FINAL_PASS
 }
 
-model user {
+model users {
   user_id String @id @default(uuid()) @map("user_id")
   email String @unique @map("email")
   password String @map("password")
@@ -36,13 +36,22 @@ model user {
   updated_at DateTime @updatedAt @map("updated_at")
 
   user_info user_info?
+  user_refresh_token user_refresh_token?
   resume resume[]
   resume_status_change_log  resume_status_change_log[]
-  @@map("user")
+  @@map("users")
 
   @@index([email], name:"idx_user_email")
 }
+model user_refresh_token {
+  token_id String @id @default(uuid()) @map("token_id")
+  user_id String @map("user_id") @unique
+  token String @map("token") @db.Text
 
+  user users @relation(fields: [user_id],references: [user_id],onDelete: Cascade)
+
+  @@index([user_id],name:"idx_user_refresh_token_user_id")
+}
 model user_info {
   user_info_id String @id @default(uuid()) @map("user_info_id")
   user_id String @unique @map("user_id")
@@ -55,7 +64,7 @@ model user_info {
   updated_at DateTime @updatedAt @map("updated_at")
 
 
-  user user @relation(fields: [user_id], references: [user_id],onDelete: Cascade)
+  user users @relation(fields: [user_id], references: [user_id],onDelete: Cascade)
   @@map("user_info")
 
   @@index([user_id],name:"idx_user_info_user_id")
@@ -70,7 +79,7 @@ model resume{
   created_at DateTime @map("created_at") @default(now())
   updated_at DateTime @updatedAt @map("updated_at")
 
-  user user @relation(fields: [user_id],references: [user_id],onDelete: Cascade)
+  user users @relation(fields: [user_id],references: [user_id],onDelete: Cascade)
   resume_status_change_log resume_status_change_log[]
 
   @@map("resume")
@@ -88,7 +97,7 @@ model resume_status_change_log{
   new_status Status @map("new_status")
   created_at DateTime @default(now()) @map("created_at")
 
-  user user @relation(fields: [changed_by],references: [user_id],onDelete: Cascade)
+  user users @relation(fields: [changed_by],references: [user_id],onDelete: Cascade)
   resume resume @relation(fields: [resume_id],references: [resume_id],onDelete: Cascade)
   @@map("resume_status_change_log")
 

--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -1,12 +1,34 @@
 import ErrorHandler from "../utils/errorHandler/errorHandler.js";
-import { verifyAccessToken } from "../utils/jwt/jwt.js";
+import { verifyAccessToken, verifyRefreshToken } from "../utils/jwt/jwt.js";
 import { prisma } from "../utils/prisma/prisma.util.js";
 import STATUS_CODES from "../utils/statusCode.js";
+import crypto from "crypto";
 
-export const authorizeUser = async (req, res, next) => {
+export const authenticateUser = async (req, res, next) => {
   try {
     const token = getTokenFromHeaders(req.headers);
     req.user = await getUserFromToken(token);
+    next();
+  } catch (error) {
+    res.clearCookie("authorization");
+    next(error);
+  }
+};
+
+export const requireRoles = (roles) => {
+  return (req, res, next) => {
+    if (!roles.includes(req.user.role)) {
+      throw new ErrorHandler(STATUS_CODES.FORBIDDEN, "접근권한이 존재하지않습니다.");
+    }
+    next();
+  };
+};
+
+export const authenticateRefreshToken = async (req, res, next) => {
+  try {
+    const token = getTokenFromHeaders(req.headers);
+
+    req.user = await getUserFromRefreshToken(token);
     next();
   } catch (error) {
     res.clearCookie("authorization");
@@ -31,7 +53,8 @@ const getUserFromToken = async (token) => {
   if (!userId) {
     throw new ErrorHandler(401, "인증 정보와 일치하는 사용자가 없습니다.");
   }
-  const user = await prisma.user.findFirst({
+
+  const user = await prisma.users.findFirst({
     where: { user_id: userId },
     select: {
       user_id: true,
@@ -53,12 +76,39 @@ const getUserFromToken = async (token) => {
 
   return formattedData;
 };
+const getUserFromRefreshToken = async (token) => {
+  const decodedToken = verifyRefreshToken(token);
+  const userId = decodedToken.user_id;
+  if (!userId) {
+    throw new ErrorHandler(401, "인증 정보가 없습니다.");
+  }
 
-export const requireRoles = (roles) => {
-  return (req, res, next) => {
-    if (!roles.includes(req.user.role)) {
-      throw new ErrorHandler(STATUS_CODES.FORBIDDEN, "접근권한이 존재하지않습니다.");
+  const user = await prisma.users.findFirst({
+    where: { user_id: userId },
+    select: {
+      user_id: true,
+      user_refresh_token: {
+        select: {
+          token: true
+        }
+      }
     }
-    next();
+  });
+  if (!user) {
+    throw new ErrorHandler(401, "인증 정보와 일치하는 사용자가 없습니다.");
+  }
+  if (!user.user_refresh_token) {
+    throw new ErrorHandler(401, "인증 정보가 없습니다.");
+  }
+
+  const hashedRefreshToken = crypto.createHash("sha256").update(token).digest("hex");
+
+  if (hashedRefreshToken !== user.user_refresh_token.token) {
+    throw new ErrorHandler("401", "폐기된 인증 정보입니다.");
+  }
+  const formattedData = {
+    user_id: user.user_id
   };
+
+  return formattedData;
 };

--- a/src/routes/auth.route.js
+++ b/src/routes/auth.route.js
@@ -1,8 +1,11 @@
 import express from "express";
-import { loginUser, registerUser } from "../controllers/auth.controller.js";
+import { loginUser, logoutUser, refreshAuthToken, registerUser } from "../controllers/auth.controller.js";
+import { authenticateRefreshToken } from "../middlewares/auth.middleware.js";
 const router = express.Router();
 
 //유저 회원가입
 router.post("/auth/register", registerUser);
 router.post("/auth/login", loginUser);
+router.get("/auth/token", authenticateRefreshToken, refreshAuthToken);
+router.delete("/auth/logout", authenticateRefreshToken, logoutUser);
 export default router;

--- a/src/routes/resume.route.js
+++ b/src/routes/resume.route.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { authorizeUser, requireRoles } from "../middlewares/auth.middleware.js";
+import { authenticateUser, requireRoles } from "../middlewares/auth.middleware.js";
 import {
   createResume,
   updateResume,
@@ -14,24 +14,24 @@ import {
 const router = express.Router();
 
 //유저 이력서
-router.post("/resume", authorizeUser, createResume);
-router.get("/resume", authorizeUser, requireRoles(["APPLICANT", "RECRUITER"]), (req, res, next) => {
+router.post("/resume", authenticateUser, createResume);
+router.get("/resume", authenticateUser, requireRoles(["APPLICANT", "RECRUITER"]), (req, res, next) => {
   if (req.user.role === "RECRUITER") {
     getResumesForRECRUITER(req, res, next);
   } else {
     getResumesForAPPLICANT(req, res, next);
   }
 });
-router.get("/resume/:resumeId", authorizeUser, requireRoles(["APPLICANT", "RECRUITER"]), (req, res, next) => {
+router.get("/resume/:resumeId", authenticateUser, requireRoles(["APPLICANT", "RECRUITER"]), (req, res, next) => {
   if (req.user.role === "RECRUITER") {
     getResumeForRECRUITER(req, res, next);
   } else {
     getResumeForAPPLICANT(req, res, next);
   }
 });
-router.patch("/resume/:resumeId", authorizeUser, updateResume);
-router.delete("/resume/:resumeId", authorizeUser, deleteResume);
-router.patch("/resume/:resumeId/status", authorizeUser, requireRoles(["RECRUITER"]), updateResumeStatus);
-router.get("/resume/:resumeId/logs", authorizeUser, requireRoles(["RECRUITER"]), getUpdatedResumeLog);
+router.patch("/resume/:resumeId", authenticateUser, updateResume);
+router.delete("/resume/:resumeId", authenticateUser, deleteResume);
+router.patch("/resume/:resumeId/status", authenticateUser, requireRoles(["RECRUITER"]), updateResumeStatus);
+router.get("/resume/:resumeId/logs", authenticateUser, requireRoles(["RECRUITER"]), getUpdatedResumeLog);
 
 export default router;

--- a/src/routes/user.route.js
+++ b/src/routes/user.route.js
@@ -1,9 +1,9 @@
 import express from "express";
 import { getUser } from "../controllers/user.controller.js";
-import { authorizeUser } from "../middlewares/auth.middleware.js";
+import { authenticateUser } from "../middlewares/auth.middleware.js";
 const router = express.Router();
 
 //유저 회원가입
-router.get("/user", authorizeUser, getUser);
+router.get("/user", authenticateUser, getUser);
 
 export default router;

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -1,12 +1,12 @@
 import { prisma } from "../utils/prisma/prisma.util.js";
 import ErrorHandler from "../utils/errorHandler/errorHandler.js";
-
+import crypto from "crypto";
 import bcrypt from "bcrypt";
-import { generateAccessToken } from "../utils/jwt/jwt.js";
+import { generateAccessToken, generateRefreshToken } from "../utils/jwt/jwt.js";
 
 // 해당 유저가 존재하는 지 확인 하는 함수.
 export const checkUserExists = async (email) => {
-  const user = await prisma.user.findFirst({ where: { email } });
+  const user = await prisma.users.findFirst({ where: { email } });
   //!! 를 사용 함으로 명시작으로 boolean 값을 돌려줄수있음
   return user;
 };
@@ -18,7 +18,7 @@ export const createUser = async (user) => {
   }
   const hashedPassword = await bcrypt.hash(user.password, 10);
   return await prisma.$transaction(async (tx) => {
-    const newUser = await tx.user.create({
+    const newUser = await tx.users.create({
       data: {
         email: user.email,
         password: hashedPassword
@@ -46,7 +46,45 @@ export const authenticateUser = async (user) => {
   if (!isExitsUser || !(await bcrypt.compare(user.password, isExitsUser.password))) {
     throw new ErrorHandler(401, "인증 정보가 유효하지 않습니다.");
   }
-  console.log(isExitsUser);
   const accessToken = generateAccessToken(isExitsUser.user_id);
-  return accessToken;
+  const refreshToken = generateRefreshToken(isExitsUser.user_id);
+  const hashedRefreshToken = crypto.createHash("sha256").update(refreshToken).digest("hex");
+  const isExistRefreshToken = await prisma.user_refresh_token.findFirst({ where: { user_id: isExitsUser.user_id } });
+
+  if (isExistRefreshToken) {
+    await prisma.user_refresh_token.update({
+      where: { user_id: isExitsUser.user_id },
+      data: {
+        token: hashedRefreshToken
+      }
+    });
+  } else {
+    await prisma.user_refresh_token.create({
+      data: {
+        token: hashedRefreshToken,
+        user_id: isExitsUser.user_id
+      }
+    });
+  }
+
+  return [accessToken, refreshToken];
+};
+//토큰 재생성 함수
+export const regenerateToken = async (userId) => {
+  const accessToken = generateAccessToken(userId);
+  const refreshToken = generateRefreshToken(userId);
+
+  const hashedRefreshToken = crypto.createHash("sha256").update(refreshToken).digest("hex");
+
+  await prisma.user_refresh_token.update({
+    where: { user_id: userId },
+    data: {
+      token: hashedRefreshToken
+    }
+  });
+  return [accessToken, refreshToken];
+};
+
+export const deleteUserToken = async (userId) => {
+  return await prisma.user_refresh_token.delete({ where: { user_id: userId } });
 };

--- a/src/services/resume.service.js
+++ b/src/services/resume.service.js
@@ -264,7 +264,7 @@ export const getUpdatedResumeLogForRECRUITER = async (resumeId) => {
       new_status: true,
       reason: true,
       created_at: true,
-      user: {
+      users: {
         select: {
           user_info: {
             select: {

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -4,7 +4,7 @@ import STATUS_CODES from "../utils/statusCode.js";
 
 // 해당 유저가 존재하는 지 확인 하는 함수.
 export const getUserById = async (userId) => {
-  const user = await prisma.user.findFirst({
+  const user = await prisma.users.findFirst({
     where: { user_id: userId },
     select: {
       user_id: true,

--- a/src/utils/jwt/jwt.js
+++ b/src/utils/jwt/jwt.js
@@ -12,3 +12,10 @@ export const generateAccessToken = (userId) => {
 export const verifyAccessToken = (token) => {
   return jwt.verify(token, options.accessSecretKey);
 };
+export const generateRefreshToken = (userId) => {
+  return jwt.sign({ user_id: userId }, options.refreshSecretKey, options.refreshOption);
+};
+
+export const verifyRefreshToken = (token) => {
+  return jwt.verify(token, options.refreshSecretKey);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,6 +280,11 @@ cookie@0.6.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
   integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
 
+crypto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
+  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
## 제목: refreshToken 기반 토큰 업데이트 기능 구현, 로그아웃 기능 구현 #9

- 로그인시 refreshToken 도 함께 돌려주고, DB에 저장합니다.
- refreshToken 을 사용하는 엔드포인트는 refreshToken 용 middleware 를 구현 하였음, refresh Token을 저장하기위한 Schema 업데이트.
```js
model user_refresh_token {
  token_id String @id @default(uuid()) @map("token_id")
  user_id String @map("user_id") @unique
  token String @map("token") @db.Text

  user users @relation(fields: [user_id],references: [user_id],onDelete: Cascade)

  @@index([user_id],name:"idx_user_refresh_token_user_id")
}
``` 

- refreshToken 을 해싱 하기위해서 bcrypt 를 사용하지않고 crypto 로 리프레쉬토큰을 해싱하였음.
- 로그아웃시 토큰 테이블을 삭제합니다.